### PR TITLE
[codex] Add MT5 closed candle ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Python](https://img.shields.io/badge/Python-3.11-blue)
 ![MT5](https://img.shields.io/badge/MetaTrader-5-1f6feb)
-![Tests](https://img.shields.io/badge/tests-36%20passing-brightgreen)
+![Tests](https://img.shields.io/badge/tests-46%20passing-brightgreen)
 ![Status](https://img.shields.io/badge/status-active%20build-informational)
 
 A structure-first trading engine for a BOS-based 75% retracement strategy, built around deterministic replay, explicit state transitions, and an optional MetaTrader 5 execution adapter.
@@ -16,6 +16,7 @@ This project is intentionally conservative: it does not convert market-structure
 - Generates 75% retracement pending limit setups.
 - Emits broker-facing pending order and cancellation commands.
 - Replays seeded candle fixtures with explainable logs.
+- Fetches closed candles from MT5 for replay-ready market data.
 - Validates MT5 requests safely through `order_check` before live order sending.
 
 ## Strategy Geometry
@@ -43,6 +44,7 @@ The setup geometry preserves the intended 1:3 structure before symbol tick-size 
 ```mermaid
 flowchart LR
     A["Explicit ASH/ASL Seed"] --> B["Closed Candle Replay"]
+    M["MT5 Closed Candles"] --> B
     B --> C["BOS Detector"]
     C --> D["Setup Generator"]
     D --> E["Strategy State Machine"]
@@ -60,6 +62,7 @@ flowchart LR
 | `bos75/execution.py` | One-symbol lifecycle state machine |
 | `bos75/orders.py` | Broker-facing pending limit and cancel command models |
 | `bos75/mt5_adapter.py` | Optional MetaTrader5 Python adapter for order commands |
+| `bos75/mt5_market_data.py` | Closed-candle ingestion from MT5 |
 | `bos75/seeding.py` | Explicit ASH/ASL seeding without automatic swing invention |
 | `bos75/replay.py` | Deterministic replay coordinator for seeded closed-candle inputs |
 | `bos75/cli.py` | Replay and MT5 safety-check commands |
@@ -80,6 +83,14 @@ python -m bos75.cli replay examples/bullish_replay.json
 ```
 
 Replay output includes the current state, pending setup or position, broker commands, and replayable decision logs.
+
+Fetch closed candles from MT5:
+
+```powershell
+python -m bos75.cli mt5-candles --symbol EURUSD --timeframe M15 --count 20
+```
+
+The MT5 candle command skips the currently forming bar and returns closed candles only.
 
 ## MetaTrader 5
 
@@ -111,8 +122,8 @@ $env:BOS75_MT5_INTEGRATION='1'; python -m unittest tests.test_mt5_original_integ
 
 ## Current Validation
 
-- `36` deterministic tests pass locally.
-- The original MT5 smoke test passes against a connected demo terminal when explicitly enabled.
+- The default `46`-test suite passes locally, with the 2 original-terminal checks skipped unless explicitly enabled.
+- The original MT5 smoke and closed-candle fetch checks pass against a connected demo terminal when explicitly enabled.
 - Live `order_send` remains gated until terminal-side trading permission is enabled.
 
 ## Open Strategy Decisions

--- a/bos75/__init__.py
+++ b/bos75/__init__.py
@@ -12,6 +12,7 @@ from .models import (
     TradeSetup,
 )
 from .mt5_adapter import MT5AdapterConfig, MT5AdapterError, MT5ExecutionResult, MT5OrderAdapter
+from .mt5_market_data import MT5CandleBatch, MT5MarketDataAdapter
 from .orders import (
     CancelPendingOrderCommand,
     ExecutionCommand,
@@ -36,7 +37,9 @@ __all__ = [
     "ExplicitStructureSeeder",
     "MT5AdapterConfig",
     "MT5AdapterError",
+    "MT5CandleBatch",
     "MT5ExecutionResult",
+    "MT5MarketDataAdapter",
     "MT5OrderAdapter",
     "OrderCommandType",
     "PendingOrderType",

--- a/bos75/cli.py
+++ b/bos75/cli.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from .models import Candle, Direction, Position, StrategyState, StructureLevel, StructureState, TradeSetup
 from .mt5_adapter import MT5AdapterConfig, MT5OrderAdapter
+from .mt5_market_data import MT5MarketDataAdapter
 from .orders import PendingOrderType, PlacePendingLimitCommand
 from .replay import ReplayEngine, ReplayStep
 from .seeding import ExplicitStructureSeed
@@ -40,6 +41,21 @@ def main(argv: list[str] | None = None) -> int:
     )
     smoke_parser.add_argument("--symbol", default="EURUSD", help="Preferred symbol for order_check")
 
+    candles_parser = subparsers.add_parser(
+        "mt5-candles",
+        help="Fetch closed candles from MT5 as JSON",
+    )
+    candles_parser.add_argument("--symbol", default="EURUSD", help="Symbol to fetch")
+    candles_parser.add_argument("--timeframe", default="M15", help="MT5 timeframe such as M1, M15, H1, H4")
+    candles_parser.add_argument("--count", type=int, default=20, help="Number of closed candles to fetch")
+    candles_parser.add_argument("--start-index", type=int, default=0, help="Index to assign to the first candle")
+    candles_parser.add_argument(
+        "--terminal-path",
+        default=r"C:\Program Files\MetaTrader 5\terminal64.exe",
+        help="Path to terminal64.exe",
+    )
+    candles_parser.add_argument("--output", type=Path, help="Optional path to write candle JSON")
+
     args = parser.parse_args(argv)
     if args.command == "replay":
         payload = json.loads(args.fixture.read_text(encoding="utf-8"))
@@ -57,6 +73,20 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "mt5-smoke":
         result = smoke_mt5_order_check(args.terminal_path, args.symbol)
         sys.stdout.write(json.dumps(result, indent=2) + "\n")
+        return 0
+    if args.command == "mt5-candles":
+        result = fetch_mt5_candles(
+            terminal_path=args.terminal_path,
+            symbol=args.symbol,
+            timeframe=args.timeframe,
+            count=args.count,
+            start_index=args.start_index,
+        )
+        output = json.dumps(result, indent=2)
+        if args.output:
+            args.output.write_text(output + "\n", encoding="utf-8")
+        else:
+            sys.stdout.write(output + "\n")
         return 0
 
     raise AssertionError(f"unhandled command {args.command}")
@@ -160,6 +190,28 @@ def smoke_mt5_order_check(terminal_path: str | None, symbol: str = "EURUSD") -> 
             "order_check_message": result.message,
             "request": result.request,
         }
+    finally:
+        adapter.shutdown()
+
+
+def fetch_mt5_candles(
+    *,
+    terminal_path: str | None,
+    symbol: str,
+    timeframe: str,
+    count: int,
+    start_index: int = 0,
+) -> dict[str, Any]:
+    adapter = MT5MarketDataAdapter(MT5AdapterConfig(terminal_path=terminal_path))
+    adapter.connect()
+    try:
+        batch = adapter.fetch_closed_candles(
+            symbol=symbol,
+            timeframe=timeframe,
+            count=count,
+            start_index=start_index,
+        )
+        return batch.to_dict()
     finally:
         adapter.shutdown()
 

--- a/bos75/mt5_market_data.py
+++ b/bos75/mt5_market_data.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+from .models import Candle
+from .mt5_adapter import MT5AdapterConfig, MT5AdapterError
+
+
+SUPPORTED_TIMEFRAMES = {
+    "M1": "TIMEFRAME_M1",
+    "M2": "TIMEFRAME_M2",
+    "M3": "TIMEFRAME_M3",
+    "M4": "TIMEFRAME_M4",
+    "M5": "TIMEFRAME_M5",
+    "M6": "TIMEFRAME_M6",
+    "M10": "TIMEFRAME_M10",
+    "M12": "TIMEFRAME_M12",
+    "M15": "TIMEFRAME_M15",
+    "M20": "TIMEFRAME_M20",
+    "M30": "TIMEFRAME_M30",
+    "H1": "TIMEFRAME_H1",
+    "H2": "TIMEFRAME_H2",
+    "H3": "TIMEFRAME_H3",
+    "H4": "TIMEFRAME_H4",
+    "H6": "TIMEFRAME_H6",
+    "H8": "TIMEFRAME_H8",
+    "H12": "TIMEFRAME_H12",
+    "D1": "TIMEFRAME_D1",
+    "W1": "TIMEFRAME_W1",
+    "MN1": "TIMEFRAME_MN1",
+}
+
+
+@dataclass(frozen=True)
+class MT5CandleBatch:
+    symbol: str
+    timeframe: str
+    candles: list[Candle]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "symbol": self.symbol,
+            "timeframe": self.timeframe,
+            "count": len(self.candles),
+            "candles": [
+                {
+                    "symbol": candle.symbol,
+                    "timestamp": candle.timestamp,
+                    "index": candle.index,
+                    "open": str(candle.open),
+                    "high": str(candle.high),
+                    "low": str(candle.low),
+                    "close": str(candle.close),
+                }
+                for candle in self.candles
+            ],
+        }
+
+
+class MT5MarketDataAdapter:
+    """Reads closed OHLC candles from the MetaTrader5 terminal."""
+
+    def __init__(self, config: MT5AdapterConfig | None = None, mt5_client: Any | None = None) -> None:
+        self.config = config or MT5AdapterConfig()
+        self.mt5 = mt5_client or self._load_mt5_client()
+
+    def connect(self) -> None:
+        initialize_kwargs = {}
+        if self.config.terminal_path:
+            initialize_kwargs["path"] = self.config.terminal_path
+        if not self.mt5.initialize(**initialize_kwargs):
+            raise MT5AdapterError(f"MT5 initialize failed: {self.mt5.last_error()}")
+
+        if self.config.login is not None:
+            login_kwargs: dict[str, Any] = {"login": self.config.login}
+            if self.config.password is not None:
+                login_kwargs["password"] = self.config.password
+            if self.config.server is not None:
+                login_kwargs["server"] = self.config.server
+            if not self.mt5.login(**login_kwargs):
+                raise MT5AdapterError(f"MT5 login failed: {self.mt5.last_error()}")
+
+    def shutdown(self) -> None:
+        self.mt5.shutdown()
+
+    def fetch_closed_candles(
+        self,
+        symbol: str,
+        timeframe: str,
+        count: int,
+        *,
+        start_index: int = 0,
+    ) -> MT5CandleBatch:
+        if count <= 0:
+            raise ValueError("count must be positive")
+
+        normalized_timeframe = normalize_timeframe(timeframe)
+        mt5_timeframe = timeframe_to_mt5(self.mt5, normalized_timeframe)
+        symbol_info = self._ensure_symbol_visible(symbol)
+
+        rates = self.mt5.copy_rates_from_pos(symbol, mt5_timeframe, 1, count)
+        if rates is None or len(rates) == 0:
+            raise MT5AdapterError(f"MT5 returned no closed candles for {symbol} {normalized_timeframe}")
+
+        candles = rates_to_candles(
+            symbol,
+            rates,
+            start_index=start_index,
+            digits=getattr(symbol_info, "digits", None),
+        )
+        return MT5CandleBatch(symbol=symbol, timeframe=normalized_timeframe, candles=candles)
+
+    def _ensure_symbol_visible(self, symbol: str) -> Any:
+        info = self.mt5.symbol_info(symbol)
+        if info is None:
+            raise MT5AdapterError(f"symbol {symbol} is not available in MT5")
+        if getattr(info, "visible", False):
+            return info
+        if not self.mt5.symbol_select(symbol, True):
+            raise MT5AdapterError(f"symbol {symbol} is not visible and could not be selected")
+        info = self.mt5.symbol_info(symbol)
+        if info is None:
+            raise MT5AdapterError(f"symbol {symbol} was selected but is not available in MT5")
+        return info
+
+    @staticmethod
+    def _load_mt5_client() -> Any:
+        try:
+            import MetaTrader5 as mt5
+        except ImportError as exc:
+            raise MT5AdapterError(
+                "MetaTrader5 Python package is not installed. Install with: python -m pip install MetaTrader5"
+            ) from exc
+        return mt5
+
+
+def normalize_timeframe(timeframe: str) -> str:
+    normalized = timeframe.strip().upper()
+    if normalized not in SUPPORTED_TIMEFRAMES:
+        supported = ", ".join(sorted(SUPPORTED_TIMEFRAMES))
+        raise ValueError(f"unsupported timeframe {timeframe!r}; supported values: {supported}")
+    return normalized
+
+
+def timeframe_to_mt5(mt5_client: Any, timeframe: str) -> int:
+    normalized = normalize_timeframe(timeframe)
+    constant_name = SUPPORTED_TIMEFRAMES[normalized]
+    try:
+        return int(getattr(mt5_client, constant_name))
+    except AttributeError as exc:
+        raise MT5AdapterError(f"MT5 client is missing {constant_name}") from exc
+
+
+def rates_to_candles(
+    symbol: str,
+    rates: Iterable[Any],
+    *,
+    start_index: int = 0,
+    digits: int | None = None,
+) -> list[Candle]:
+    sorted_rates = sorted(rates, key=lambda rate: int(_rate_value(rate, "time")))
+    return [
+        Candle(
+            symbol=symbol,
+            timestamp=_timestamp_to_utc_iso(int(_rate_value(rate, "time"))),
+            index=start_index + offset,
+            open=_price_to_str(_rate_value(rate, "open"), digits),
+            high=_price_to_str(_rate_value(rate, "high"), digits),
+            low=_price_to_str(_rate_value(rate, "low"), digits),
+            close=_price_to_str(_rate_value(rate, "close"), digits),
+        )
+        for offset, rate in enumerate(sorted_rates)
+    ]
+
+
+def _rate_value(rate: Any, key: str) -> Any:
+    if isinstance(rate, dict):
+        return rate[key]
+    try:
+        return rate[key]
+    except (TypeError, KeyError, IndexError, ValueError):
+        return getattr(rate, key)
+
+
+def _timestamp_to_utc_iso(timestamp: int) -> str:
+    return datetime.fromtimestamp(timestamp, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _price_to_str(value: Any, digits: int | None) -> str:
+    if digits is None:
+        return str(value)
+    return f"{float(value):.{int(digits)}f}"

--- a/tests/test_mt5_market_data.py
+++ b/tests/test_mt5_market_data.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+
+from bos75 import MT5AdapterConfig, MT5MarketDataAdapter
+from bos75.mt5_adapter import MT5AdapterError
+from bos75.mt5_market_data import normalize_timeframe, rates_to_candles, timeframe_to_mt5
+
+
+class FakeMT5MarketData:
+    TIMEFRAME_M1 = 1
+    TIMEFRAME_M15 = 15
+    TIMEFRAME_H1 = 16385
+    TIMEFRAME_H4 = 16388
+
+    def __init__(self) -> None:
+        self.initialized_with = None
+        self.shutdown_called = False
+        self.selected_symbols = []
+        self.copy_rates_calls = []
+        self.visible = True
+        self.rates = [
+            {"time": 1776801000, "open": 1.1, "high": 1.2, "low": 1.0, "close": 1.15},
+            {"time": 1776800100, "open": 1.0, "high": 1.15, "low": 0.95, "close": 1.1},
+        ]
+
+    def initialize(self, **kwargs):
+        self.initialized_with = kwargs
+        return True
+
+    def shutdown(self):
+        self.shutdown_called = True
+
+    def last_error(self):
+        return (1, "fake error")
+
+    def symbol_info(self, symbol):
+        return SimpleNamespace(name=symbol, visible=self.visible, digits=5)
+
+    def symbol_select(self, symbol, selected):
+        self.selected_symbols.append((symbol, selected))
+        self.visible = True
+        return True
+
+    def copy_rates_from_pos(self, symbol, timeframe, start_pos, count):
+        self.copy_rates_calls.append((symbol, timeframe, start_pos, count))
+        return self.rates[:count]
+
+
+class MT5MarketDataTests(unittest.TestCase):
+    def test_normalize_timeframe_accepts_common_values(self) -> None:
+        self.assertEqual(normalize_timeframe("m15"), "M15")
+        self.assertEqual(normalize_timeframe(" H1 "), "H1")
+
+    def test_normalize_timeframe_rejects_unknown_values(self) -> None:
+        with self.assertRaises(ValueError):
+            normalize_timeframe("M7")
+
+    def test_timeframe_to_mt5_uses_client_constant(self) -> None:
+        self.assertEqual(timeframe_to_mt5(FakeMT5MarketData(), "M15"), 15)
+
+    def test_timeframe_to_mt5_raises_for_missing_constant(self) -> None:
+        fake = FakeMT5MarketData()
+        delattr(FakeMT5MarketData, "TIMEFRAME_H4")
+        try:
+            with self.assertRaises(MT5AdapterError):
+                timeframe_to_mt5(fake, "H4")
+        finally:
+            FakeMT5MarketData.TIMEFRAME_H4 = 16388
+
+    def test_rates_to_candles_sorts_by_time_and_assigns_indexes(self) -> None:
+        candles = rates_to_candles(
+            "EURUSD",
+            [
+                {"time": 200, "open": 2, "high": 3, "low": 1, "close": 2.5},
+                {"time": 100, "open": 1, "high": 2, "low": 0.5, "close": 1.5},
+            ],
+            start_index=10,
+        )
+
+        self.assertEqual([candle.index for candle in candles], [10, 11])
+        self.assertEqual([candle.timestamp for candle in candles], [
+            "1970-01-01T00:01:40Z",
+            "1970-01-01T00:03:20Z",
+        ])
+        self.assertEqual(str(candles[0].close), "1.5")
+
+    def test_rates_to_candles_can_format_prices_to_symbol_digits(self) -> None:
+        candles = rates_to_candles(
+            "EURUSD",
+            [{"time": 100, "open": 1.1, "high": 1.23456789, "low": 1.0, "close": 1.1740599999999999}],
+            digits=5,
+        )
+
+        self.assertEqual(str(candles[0].open), "1.10000")
+        self.assertEqual(str(candles[0].high), "1.23457")
+        self.assertEqual(str(candles[0].close), "1.17406")
+
+    def test_fetch_closed_candles_skips_current_bar(self) -> None:
+        fake = FakeMT5MarketData()
+        adapter = MT5MarketDataAdapter(MT5AdapterConfig(terminal_path="terminal"), mt5_client=fake)
+
+        adapter.connect()
+        batch = adapter.fetch_closed_candles("EURUSD", "M15", 2, start_index=5)
+        adapter.shutdown()
+
+        self.assertEqual(fake.initialized_with["path"], "terminal")
+        self.assertEqual(fake.copy_rates_calls, [("EURUSD", 15, 1, 2)])
+        self.assertTrue(fake.shutdown_called)
+        self.assertEqual(batch.symbol, "EURUSD")
+        self.assertEqual(batch.timeframe, "M15")
+        self.assertEqual([candle.index for candle in batch.candles], [5, 6])
+
+    def test_fetch_closed_candles_selects_hidden_symbol(self) -> None:
+        fake = FakeMT5MarketData()
+        fake.visible = False
+        adapter = MT5MarketDataAdapter(mt5_client=fake)
+
+        adapter.connect()
+        adapter.fetch_closed_candles("EURUSD", "M1", 1)
+
+        self.assertEqual(fake.selected_symbols, [("EURUSD", True)])
+
+    def test_batch_serializes_candles_for_json(self) -> None:
+        fake = FakeMT5MarketData()
+        adapter = MT5MarketDataAdapter(mt5_client=fake)
+
+        adapter.connect()
+        payload = adapter.fetch_closed_candles("EURUSD", "M15", 1).to_dict()
+
+        self.assertEqual(payload["symbol"], "EURUSD")
+        self.assertEqual(payload["timeframe"], "M15")
+        self.assertEqual(payload["count"], 1)
+        self.assertEqual(payload["candles"][0]["open"], "1.10000")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mt5_original_integration.py
+++ b/tests/test_mt5_original_integration.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import unittest
 
-from bos75.cli import smoke_mt5_order_check
+from bos75.cli import fetch_mt5_candles, smoke_mt5_order_check
 
 
 @unittest.skipUnless(
@@ -20,6 +20,18 @@ class OriginalMT5IntegrationTests(unittest.TestCase):
         self.assertTrue(result["ok"], result)
         self.assertEqual(result["order_check_retcode"], 0)
         self.assertIn(result["symbol"], {"EURUSD", "GBPUSD", "USDJPY"})
+
+    def test_original_terminal_closed_candle_fetch(self) -> None:
+        result = fetch_mt5_candles(
+            terminal_path=os.environ.get("BOS75_MT5_TERMINAL_PATH", r"C:\Program Files\MetaTrader 5\terminal64.exe"),
+            symbol=os.environ.get("BOS75_MT5_SYMBOL", "EURUSD"),
+            timeframe=os.environ.get("BOS75_MT5_TIMEFRAME", "M15"),
+            count=3,
+        )
+
+        self.assertEqual(result["symbol"], os.environ.get("BOS75_MT5_SYMBOL", "EURUSD"))
+        self.assertEqual(result["count"], 3)
+        self.assertEqual([candle["index"] for candle in result["candles"]], [0, 1, 2])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- Added `bos75/mt5_market_data.py` for closed-candle ingestion from MetaTrader 5.
- Added timeframe normalization and MT5 timeframe constant mapping.
- Added conversion from MT5 rates into existing `Candle` models with symbol-digit price formatting.
- Added `python -m bos75.cli mt5-candles --symbol EURUSD --timeframe M15 --count 20`.
- Extended opt-in original-terminal integration tests to cover real closed-candle fetching.
- Updated README architecture, quickstart, module list, and validation notes.

## Why

This moves the system closer to real operation while staying inside the strategy guardrails: it fetches closed candles only and does not invent ASH/ASL, detect pivots, or place trades.

## Validation

```powershell
python -m unittest discover -s tests -v
$env:BOS75_MT5_INTEGRATION='1'; python -m unittest tests.test_mt5_original_integration -v
python -m bos75.cli mt5-candles --symbol EURUSD --timeframe M15 --count 3
```

Results:

- Default suite: 46 tests passing, 2 original-terminal checks skipped by default.
- Opt-in original MT5 integration: 2 tests passing.
- Real EURUSD M15 candle fetch returned 3 closed candles with clean 5-digit price formatting.

Related to #1, but does not resolve automatic structure seeding.