### PR TITLE
[codex] Add persisted dry-run live loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ dist/
 .env.*
 
 tools/
+state/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Python](https://img.shields.io/badge/Python-3.11-blue)
 ![MT5](https://img.shields.io/badge/MetaTrader-5-1f6feb)
-![Tests](https://img.shields.io/badge/tests-46%20passing-brightgreen)
+![Tests](https://img.shields.io/badge/tests-54%20passing-brightgreen)
 ![Status](https://img.shields.io/badge/status-active%20build-informational)
 
 A structure-first trading engine for a BOS-based 75% retracement strategy, built around deterministic replay, explicit state transitions, and an optional MetaTrader 5 execution adapter.
@@ -17,6 +17,7 @@ This project is intentionally conservative: it does not convert market-structure
 - Emits broker-facing pending order and cancellation commands.
 - Replays seeded candle fixtures with explainable logs.
 - Fetches closed candles from MT5 for replay-ready market data.
+- Runs a persisted dry-run live loop over new closed candles.
 - Validates MT5 requests safely through `order_check` before live order sending.
 
 ## Strategy Geometry
@@ -63,6 +64,8 @@ flowchart LR
 | `bos75/orders.py` | Broker-facing pending limit and cancel command models |
 | `bos75/mt5_adapter.py` | Optional MetaTrader5 Python adapter for order commands |
 | `bos75/mt5_market_data.py` | Closed-candle ingestion from MT5 |
+| `bos75/persistence.py` | JSON runtime state save/restore |
+| `bos75/live_loop.py` | Persisted dry-run live loop over MT5 closed candles |
 | `bos75/seeding.py` | Explicit ASH/ASL seeding without automatic swing invention |
 | `bos75/replay.py` | Deterministic replay coordinator for seeded closed-candle inputs |
 | `bos75/cli.py` | Replay and MT5 safety-check commands |
@@ -91,6 +94,25 @@ python -m bos75.cli mt5-candles --symbol EURUSD --timeframe M15 --count 20
 ```
 
 The MT5 candle command skips the currently forming bar and returns closed candles only.
+
+Run one persisted dry-run live cycle:
+
+```powershell
+python -m bos75.cli live-dry-run `
+  --symbol EURUSD `
+  --timeframe M15 `
+  --state-path state/EURUSD_M15.json `
+  --seed-ash-price 1.20000 `
+  --seed-ash-time manual-high `
+  --seed-ash-index 0 `
+  --seed-asl-price 1.10000 `
+  --seed-asl-time manual-low `
+  --seed-asl-index 0
+```
+
+The dry-run loop processes new closed candles only, persists JSON state, and emits logs/commands without sending orders.
+
+On later runs, the same command can omit seed arguments once the state file exists.
 
 ## MetaTrader 5
 
@@ -122,7 +144,7 @@ $env:BOS75_MT5_INTEGRATION='1'; python -m unittest tests.test_mt5_original_integ
 
 ## Current Validation
 
-- The default `46`-test suite passes locally, with the 2 original-terminal checks skipped unless explicitly enabled.
+- The default `54`-test suite passes locally, with the 2 original-terminal checks skipped unless explicitly enabled.
 - The original MT5 smoke and closed-candle fetch checks pass against a connected demo terminal when explicitly enabled.
 - Live `order_send` remains gated until terminal-side trading permission is enabled.
 

--- a/bos75/__init__.py
+++ b/bos75/__init__.py
@@ -1,6 +1,7 @@
 """BOS 75% retracement strategy core."""
 
 from .execution import StrategyEngine
+from .live_loop import DryRunLiveConfig, DryRunLiveLoop, DryRunLiveResult
 from .models import (
     BOSEvent,
     Candle,
@@ -32,6 +33,9 @@ __all__ = [
     "Candle",
     "CancelPendingOrderCommand",
     "Direction",
+    "DryRunLiveConfig",
+    "DryRunLiveLoop",
+    "DryRunLiveResult",
     "ExecutionCommand",
     "ExpansionLeg",
     "ExplicitStructureSeed",

--- a/bos75/__init__.py
+++ b/bos75/__init__.py
@@ -20,6 +20,7 @@ from .orders import (
     PendingOrderType,
     PlacePendingLimitCommand,
 )
+from .persistence import JsonStateStore, RuntimeState
 from .replay import ReplayEngine, ReplaySnapshot, ReplayStep
 from .seeding import ExplicitStructureSeed, ExplicitStructureSeeder, StructureSeedResult
 from .setup_generation import SetupGenerator
@@ -35,6 +36,7 @@ __all__ = [
     "ExpansionLeg",
     "ExplicitStructureSeed",
     "ExplicitStructureSeeder",
+    "JsonStateStore",
     "MT5AdapterConfig",
     "MT5AdapterError",
     "MT5CandleBatch",
@@ -47,6 +49,7 @@ __all__ = [
     "ReplayEngine",
     "ReplaySnapshot",
     "ReplayStep",
+    "RuntimeState",
     "SetupGenerator",
     "StrategyEngine",
     "StrategyState",

--- a/bos75/cli.py
+++ b/bos75/cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from .models import Candle, Direction, Position, StrategyState, StructureLevel, StructureState, TradeSetup
+from .live_loop import DryRunLiveConfig, DryRunLiveLoop
 from .mt5_adapter import MT5AdapterConfig, MT5OrderAdapter
 from .mt5_market_data import MT5MarketDataAdapter
 from .orders import PendingOrderType, PlacePendingLimitCommand
@@ -56,6 +57,29 @@ def main(argv: list[str] | None = None) -> int:
     )
     candles_parser.add_argument("--output", type=Path, help="Optional path to write candle JSON")
 
+    live_parser = subparsers.add_parser(
+        "live-dry-run",
+        help="Process new MT5 closed candles into persisted strategy state without sending orders",
+    )
+    live_parser.add_argument("--symbol", default="EURUSD", help="Symbol to process")
+    live_parser.add_argument("--timeframe", default="M15", help="MT5 timeframe such as M15 or H1")
+    live_parser.add_argument("--lookback", type=int, default=20, help="Closed candles to fetch each run")
+    live_parser.add_argument("--state-path", type=Path, required=True, help="JSON state file path")
+    live_parser.add_argument(
+        "--terminal-path",
+        default=r"C:\Program Files\MetaTrader 5\terminal64.exe",
+        help="Path to terminal64.exe",
+    )
+    live_parser.add_argument("--seed-ash-price", help="Initial active structural high price")
+    live_parser.add_argument("--seed-ash-time", help="Initial active structural high timestamp")
+    live_parser.add_argument("--seed-ash-index", type=int, help="Initial active structural high candle index")
+    live_parser.add_argument("--seed-asl-price", help="Initial active structural low price")
+    live_parser.add_argument("--seed-asl-time", help="Initial active structural low timestamp")
+    live_parser.add_argument("--seed-asl-index", type=int, help="Initial active structural low candle index")
+    live_parser.add_argument("--bullish-leg-start-index", type=int)
+    live_parser.add_argument("--bearish-leg-start-index", type=int)
+    live_parser.add_argument("--output", type=Path, help="Optional path to write dry-run result JSON")
+
     args = parser.parse_args(argv)
     if args.command == "replay":
         payload = json.loads(args.fixture.read_text(encoding="utf-8"))
@@ -81,6 +105,23 @@ def main(argv: list[str] | None = None) -> int:
             timeframe=args.timeframe,
             count=args.count,
             start_index=args.start_index,
+        )
+        output = json.dumps(result, indent=2)
+        if args.output:
+            args.output.write_text(output + "\n", encoding="utf-8")
+        else:
+            sys.stdout.write(output + "\n")
+        return 0
+    if args.command == "live-dry-run":
+        result = run_live_dry_run(
+            symbol=args.symbol,
+            timeframe=args.timeframe,
+            lookback=args.lookback,
+            state_path=args.state_path,
+            terminal_path=args.terminal_path,
+            seed=_seed_from_live_args(args),
+            bullish_leg_start_index=args.bullish_leg_start_index,
+            bearish_leg_start_index=args.bearish_leg_start_index,
         )
         output = json.dumps(result, indent=2)
         if args.output:
@@ -216,6 +257,32 @@ def fetch_mt5_candles(
         adapter.shutdown()
 
 
+def run_live_dry_run(
+    *,
+    symbol: str,
+    timeframe: str,
+    lookback: int,
+    state_path: Path,
+    terminal_path: str | None,
+    seed: ExplicitStructureSeed | None = None,
+    bullish_leg_start_index: int | None = None,
+    bearish_leg_start_index: int | None = None,
+) -> dict[str, Any]:
+    loop = DryRunLiveLoop(
+        DryRunLiveConfig(
+            symbol=symbol,
+            timeframe=timeframe,
+            state_path=state_path,
+            lookback=lookback,
+            terminal_path=terminal_path,
+            seed=seed,
+            bullish_leg_start_index=bullish_leg_start_index,
+            bearish_leg_start_index=bearish_leg_start_index,
+        )
+    )
+    return loop.run_once().to_dict()
+
+
 def _load_seed(symbol: str, payload: dict[str, Any]) -> ExplicitStructureSeed:
     return ExplicitStructureSeed(
         symbol=symbol,
@@ -225,6 +292,30 @@ def _load_seed(symbol: str, payload: dict[str, Any]) -> ExplicitStructureSeed:
         active_low_price=str(payload["active_low"]["price"]),
         active_low_timestamp=payload["active_low"]["timestamp"],
         active_low_index=int(payload["active_low"]["index"]),
+    )
+
+
+def _seed_from_live_args(args: argparse.Namespace) -> ExplicitStructureSeed | None:
+    values = [
+        args.seed_ash_price,
+        args.seed_ash_time,
+        args.seed_ash_index,
+        args.seed_asl_price,
+        args.seed_asl_time,
+        args.seed_asl_index,
+    ]
+    if all(value is None for value in values):
+        return None
+    if any(value is None for value in values):
+        raise ValueError("explicit live seed requires all ASH and ASL seed arguments")
+    return ExplicitStructureSeed(
+        symbol=args.symbol,
+        active_high_price=str(args.seed_ash_price),
+        active_high_timestamp=args.seed_ash_time,
+        active_high_index=int(args.seed_ash_index),
+        active_low_price=str(args.seed_asl_price),
+        active_low_timestamp=args.seed_asl_time,
+        active_low_index=int(args.seed_asl_index),
     )
 
 

--- a/bos75/live_loop.py
+++ b/bos75/live_loop.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .models import Candle, LogRecord
+from .mt5_adapter import MT5AdapterConfig
+from .mt5_market_data import MT5MarketDataAdapter
+from .orders import ExecutionCommand
+from .persistence import (
+    JsonStateStore,
+    RuntimeState,
+    candle_to_dict,
+    trade_setup_to_dict,
+)
+from .replay import ReplayEngine, ReplayStep
+from .seeding import ExplicitStructureSeed
+
+
+@dataclass(frozen=True)
+class DryRunLiveConfig:
+    symbol: str
+    timeframe: str
+    state_path: Path
+    lookback: int = 20
+    terminal_path: str | None = r"C:\Program Files\MetaTrader 5\terminal64.exe"
+    seed: ExplicitStructureSeed | None = None
+    bullish_leg_start_index: int | None = None
+    bearish_leg_start_index: int | None = None
+
+
+@dataclass(frozen=True)
+class DryRunLiveResult:
+    symbol: str
+    timeframe: str
+    state_path: Path
+    fetched_count: int
+    processed_count: int
+    skipped_count: int
+    last_processed_candle_timestamp: str | None
+    next_candle_index: int
+    new_commands: list[ExecutionCommand]
+    new_logs: list[LogRecord]
+    state: RuntimeState
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "symbol": self.symbol,
+            "timeframe": self.timeframe,
+            "state_path": str(self.state_path),
+            "dry_run": True,
+            "fetched_count": self.fetched_count,
+            "processed_count": self.processed_count,
+            "skipped_count": self.skipped_count,
+            "last_processed_candle_timestamp": self.last_processed_candle_timestamp,
+            "next_candle_index": self.next_candle_index,
+            "pending_setup": trade_setup_to_dict(self.state.pending_setup),
+            "position_open": self.state.position is not None,
+            "new_commands": [command.to_dict() for command in self.new_commands],
+            "new_logs": [log.to_dict() for log in self.new_logs],
+        }
+
+
+class DryRunLiveLoop:
+    def __init__(
+        self,
+        config: DryRunLiveConfig,
+        *,
+        state_store: JsonStateStore | None = None,
+        market_data: MT5MarketDataAdapter | None = None,
+    ) -> None:
+        self.config = config
+        self.state_store = state_store or JsonStateStore(config.state_path)
+        self.market_data = market_data or MT5MarketDataAdapter(
+            MT5AdapterConfig(terminal_path=config.terminal_path)
+        )
+
+    def run_once(self) -> DryRunLiveResult:
+        state = self._load_or_initialize_state()
+        replay = replay_from_runtime_state(state)
+        previous_command_count = len(replay.strategy.commands)
+        previous_log_count = len(replay.logs)
+
+        self.market_data.connect()
+        try:
+            batch = self.market_data.fetch_closed_candles(
+                symbol=self.config.symbol,
+                timeframe=self.config.timeframe,
+                count=self.config.lookback,
+            )
+        finally:
+            self.market_data.shutdown()
+
+        new_candles = [
+            candle
+            for candle in batch.candles
+            if state.last_processed_candle_timestamp is None
+            or str(candle.timestamp) > state.last_processed_candle_timestamp
+        ]
+
+        last_processed = state.last_processed_candle_timestamp
+        next_index = state.next_candle_index
+        for candle in new_candles:
+            indexed_candle = _with_index(candle, next_index)
+            replay.feed(
+                ReplayStep(
+                    candle=indexed_candle,
+                    bullish_leg_start_index=self.config.bullish_leg_start_index,
+                    bearish_leg_start_index=self.config.bearish_leg_start_index,
+                )
+            )
+            last_processed = str(indexed_candle.timestamp)
+            next_index += 1
+
+        updated_state = runtime_state_from_replay(
+            replay,
+            symbol=self.config.symbol,
+            timeframe=self.config.timeframe,
+            last_processed_candle_timestamp=last_processed,
+            next_candle_index=next_index,
+        )
+        self.state_store.save(updated_state)
+
+        return DryRunLiveResult(
+            symbol=self.config.symbol,
+            timeframe=self.config.timeframe,
+            state_path=self.config.state_path,
+            fetched_count=len(batch.candles),
+            processed_count=len(new_candles),
+            skipped_count=len(batch.candles) - len(new_candles),
+            last_processed_candle_timestamp=last_processed,
+            next_candle_index=next_index,
+            new_commands=replay.strategy.commands[previous_command_count:],
+            new_logs=replay.logs[previous_log_count:],
+            state=updated_state,
+        )
+
+    def _load_or_initialize_state(self) -> RuntimeState:
+        existing = self.state_store.load()
+        if existing is not None:
+            if existing.symbol != self.config.symbol:
+                raise ValueError(
+                    f"state symbol {existing.symbol} does not match config symbol {self.config.symbol}"
+                )
+            if existing.timeframe != self.config.timeframe:
+                raise ValueError(
+                    f"state timeframe {existing.timeframe} does not match config timeframe {self.config.timeframe}"
+                )
+            return existing
+
+        if self.config.seed is None:
+            raise ValueError("first dry-run live execution requires an explicit structure seed")
+
+        replay = ReplayEngine(self.config.symbol)
+        structure = replay.seed_explicit_structure(self.config.seed)
+        return runtime_state_from_replay(
+            replay,
+            symbol=self.config.symbol,
+            timeframe=self.config.timeframe,
+            last_processed_candle_timestamp=None,
+            next_candle_index=0,
+            structure=structure,
+        )
+
+
+def runtime_state_from_replay(
+    replay: ReplayEngine,
+    *,
+    symbol: str,
+    timeframe: str,
+    last_processed_candle_timestamp: str | None,
+    next_candle_index: int,
+    structure: Any | None = None,
+) -> RuntimeState:
+    snapshot = replay.snapshot()
+    current_structure = structure or replay.current_structure
+    if current_structure is None:
+        raise ValueError("cannot persist runtime state without structure")
+    return RuntimeState(
+        symbol=symbol,
+        timeframe=timeframe,
+        structure=current_structure,
+        last_processed_candle_timestamp=last_processed_candle_timestamp,
+        next_candle_index=next_candle_index,
+        strategy_state=snapshot.state,
+        pending_setup=snapshot.pending_setup,
+        position=snapshot.position,
+        candles=list(replay.candles),
+        commands=list(snapshot.commands),
+        logs=list(snapshot.logs),
+    )
+
+
+def replay_from_runtime_state(state: RuntimeState) -> ReplayEngine:
+    replay = ReplayEngine(state.symbol)
+    replay.current_structure = state.structure
+    replay.candles = list(state.candles)
+    replay.logs = list(state.logs)
+    replay.strategy.state = state.strategy_state
+    replay.strategy.pending_setup = state.pending_setup
+    replay.strategy.position = state.position
+    replay.strategy.commands = list(state.commands)
+    replay.strategy.logs = []
+    replay._strategy_log_cursor = 0
+    return replay
+
+
+def _with_index(candle: Candle, index: int) -> Candle:
+    return Candle(
+        symbol=candle.symbol,
+        timestamp=candle.timestamp,
+        index=index,
+        open=candle.open,
+        high=candle.high,
+        low=candle.low,
+        close=candle.close,
+    )

--- a/bos75/persistence.py
+++ b/bos75/persistence.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+from .models import (
+    Candle,
+    Direction,
+    LogRecord,
+    Position,
+    StrategyState,
+    StructureLevel,
+    StructureState,
+    TradeSetup,
+)
+from .orders import (
+    CancelPendingOrderCommand,
+    ExecutionCommand,
+    OrderCommandType,
+    PendingOrderType,
+    PlacePendingLimitCommand,
+)
+
+
+STATE_SCHEMA_VERSION = 1
+
+
+@dataclass
+class RuntimeState:
+    symbol: str
+    timeframe: str
+    structure: StructureState
+    last_processed_candle_timestamp: str | None = None
+    next_candle_index: int = 0
+    strategy_state: StrategyState = StrategyState.WARMUP
+    pending_setup: TradeSetup | None = None
+    position: Position | None = None
+    candles: list[Candle] = field(default_factory=list)
+    commands: list[ExecutionCommand] = field(default_factory=list)
+    logs: list[LogRecord] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": STATE_SCHEMA_VERSION,
+            "symbol": self.symbol,
+            "timeframe": self.timeframe,
+            "structure": structure_to_dict(self.structure),
+            "last_processed_candle_timestamp": self.last_processed_candle_timestamp,
+            "next_candle_index": self.next_candle_index,
+            "strategy_state": self.strategy_state.value,
+            "pending_setup": trade_setup_to_dict(self.pending_setup),
+            "position": position_to_dict(self.position),
+            "candles": [candle_to_dict(candle) for candle in self.candles],
+            "commands": [command_to_dict(command) for command in self.commands],
+            "logs": [log.to_dict() for log in self.logs],
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> RuntimeState:
+        schema_version = payload.get("schema_version")
+        if schema_version != STATE_SCHEMA_VERSION:
+            raise ValueError(f"unsupported state schema version {schema_version!r}")
+
+        return cls(
+            symbol=payload["symbol"],
+            timeframe=payload["timeframe"],
+            structure=structure_from_dict(payload["structure"]),
+            last_processed_candle_timestamp=payload.get("last_processed_candle_timestamp"),
+            next_candle_index=int(payload.get("next_candle_index", 0)),
+            strategy_state=StrategyState(payload.get("strategy_state", StrategyState.WARMUP.value)),
+            pending_setup=trade_setup_from_dict(payload.get("pending_setup")),
+            position=position_from_dict(payload.get("position")),
+            candles=[candle_from_dict(item) for item in payload.get("candles", [])],
+            commands=[command_from_dict(item) for item in payload.get("commands", [])],
+            logs=[log_record_from_dict(item) for item in payload.get("logs", [])],
+        )
+
+
+class JsonStateStore:
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+
+    def load(self) -> RuntimeState | None:
+        if not self.path.exists():
+            return None
+        return RuntimeState.from_dict(json.loads(self.path.read_text(encoding="utf-8")))
+
+    def save(self, state: RuntimeState) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path = self.path.with_suffix(self.path.suffix + ".tmp")
+        temp_path.write_text(json.dumps(state.to_dict(), indent=2) + "\n", encoding="utf-8")
+        temp_path.replace(self.path)
+
+
+def candle_to_dict(candle: Candle) -> dict[str, Any]:
+    return {
+        "symbol": candle.symbol,
+        "timestamp": candle.timestamp,
+        "index": candle.index,
+        "open": str(candle.open),
+        "high": str(candle.high),
+        "low": str(candle.low),
+        "close": str(candle.close),
+    }
+
+
+def candle_from_dict(payload: dict[str, Any]) -> Candle:
+    return Candle(
+        symbol=payload["symbol"],
+        timestamp=payload["timestamp"],
+        index=int(payload["index"]),
+        open=payload["open"],
+        high=payload["high"],
+        low=payload["low"],
+        close=payload["close"],
+    )
+
+
+def structure_to_dict(structure: StructureState) -> dict[str, Any]:
+    return {
+        "symbol": structure.symbol,
+        "active_high": structure_level_to_dict(structure.active_high),
+        "active_low": structure_level_to_dict(structure.active_low),
+    }
+
+
+def structure_from_dict(payload: dict[str, Any]) -> StructureState:
+    return StructureState(
+        symbol=payload["symbol"],
+        active_high=structure_level_from_dict(payload["active_high"]),
+        active_low=structure_level_from_dict(payload["active_low"]),
+    )
+
+
+def structure_level_to_dict(level: StructureLevel) -> dict[str, Any]:
+    return {
+        "name": level.name,
+        "price": str(level.price),
+        "timestamp": level.timestamp,
+        "candle_index": level.candle_index,
+    }
+
+
+def structure_level_from_dict(payload: dict[str, Any]) -> StructureLevel:
+    return StructureLevel(
+        name=payload["name"],
+        price=payload["price"],
+        timestamp=payload["timestamp"],
+        candle_index=int(payload["candle_index"]),
+    )
+
+
+def trade_setup_to_dict(setup: TradeSetup | None) -> dict[str, Any] | None:
+    if setup is None:
+        return None
+    return {
+        "id": setup.id,
+        "symbol": setup.symbol,
+        "direction": setup.direction.value,
+        "entry": str(setup.entry),
+        "stop_loss": str(setup.stop_loss),
+        "take_profit": str(setup.take_profit),
+        "high_anchor": str(setup.high_anchor),
+        "low_anchor": str(setup.low_anchor),
+        "source_bos_id": setup.source_bos_id,
+        "created_at": setup.created_at,
+    }
+
+
+def trade_setup_from_dict(payload: dict[str, Any] | None) -> TradeSetup | None:
+    if payload is None:
+        return None
+    return TradeSetup(
+        id=payload["id"],
+        symbol=payload["symbol"],
+        direction=Direction(payload["direction"]),
+        entry=Decimal(payload["entry"]),
+        stop_loss=Decimal(payload["stop_loss"]),
+        take_profit=Decimal(payload["take_profit"]),
+        high_anchor=Decimal(payload["high_anchor"]),
+        low_anchor=Decimal(payload["low_anchor"]),
+        source_bos_id=payload["source_bos_id"],
+        created_at=payload["created_at"],
+    )
+
+
+def position_to_dict(position: Position | None) -> dict[str, Any] | None:
+    if position is None:
+        return None
+    return {
+        "id": position.id,
+        "setup": trade_setup_to_dict(position.setup),
+        "opened_at": position.opened_at,
+    }
+
+
+def position_from_dict(payload: dict[str, Any] | None) -> Position | None:
+    if payload is None:
+        return None
+    setup = trade_setup_from_dict(payload["setup"])
+    if setup is None:
+        raise ValueError("position payload must contain setup")
+    return Position(id=payload["id"], setup=setup, opened_at=payload["opened_at"])
+
+
+def command_to_dict(command: ExecutionCommand) -> dict[str, Any]:
+    return command.to_dict()
+
+
+def command_from_dict(payload: dict[str, Any]) -> ExecutionCommand:
+    command_type = OrderCommandType(payload["command_type"])
+    if command_type == OrderCommandType.PLACE_PENDING_LIMIT:
+        return PlacePendingLimitCommand(
+            id=payload["id"],
+            symbol=payload["symbol"],
+            order_type=PendingOrderType(payload["order_type"]),
+            setup_id=payload["setup_id"],
+            entry=Decimal(payload["entry"]),
+            stop_loss=Decimal(payload["stop_loss"]),
+            take_profit=Decimal(payload["take_profit"]),
+            source_bos_id=payload["source_bos_id"],
+            timestamp=payload["timestamp"],
+        )
+    if command_type == OrderCommandType.CANCEL_PENDING_ORDER:
+        return CancelPendingOrderCommand(
+            id=payload["id"],
+            symbol=payload["symbol"],
+            setup_id=payload["setup_id"],
+            reason=payload["reason"],
+            timestamp=payload["timestamp"],
+            replacement_bos_id=payload.get("replacement_bos_id"),
+        )
+    raise ValueError(f"unsupported command type {command_type}")
+
+
+def log_record_from_dict(payload: dict[str, Any]) -> LogRecord:
+    return LogRecord(
+        event=payload["event"],
+        symbol=payload["symbol"],
+        timestamp=payload.get("timestamp"),
+        message=payload["message"],
+        state_before=_state_or_none(payload.get("state_before")),
+        state_after=_state_or_none(payload.get("state_after")),
+        data=payload.get("data", {}),
+    )
+
+
+def _state_or_none(value: str | None) -> StrategyState | None:
+    if value is None:
+        return None
+    return StrategyState(value)

--- a/tests/test_live_loop.py
+++ b/tests/test_live_loop.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from decimal import Decimal
+from pathlib import Path
+
+from bos75 import (
+    Candle,
+    Direction,
+    DryRunLiveConfig,
+    DryRunLiveLoop,
+    ExplicitStructureSeed,
+    JsonStateStore,
+    OrderCommandType,
+    StrategyState,
+)
+from bos75.mt5_market_data import MT5CandleBatch
+
+
+SYMBOL = "EURUSD"
+
+
+class FakeMarketData:
+    def __init__(self, batches: list[MT5CandleBatch]) -> None:
+        self.batches = batches
+        self.connect_count = 0
+        self.shutdown_count = 0
+        self.fetch_calls = []
+
+    def connect(self) -> None:
+        self.connect_count += 1
+
+    def shutdown(self) -> None:
+        self.shutdown_count += 1
+
+    def fetch_closed_candles(self, symbol: str, timeframe: str, count: int):
+        self.fetch_calls.append((symbol, timeframe, count))
+        if len(self.fetch_calls) <= len(self.batches):
+            return self.batches[len(self.fetch_calls) - 1]
+        return self.batches[-1]
+
+
+def seed() -> ExplicitStructureSeed:
+    return ExplicitStructureSeed(
+        symbol=SYMBOL,
+        active_high_price="1.20000",
+        active_high_timestamp="seed-high",
+        active_high_index=0,
+        active_low_price="1.10000",
+        active_low_timestamp="seed-low",
+        active_low_index=0,
+    )
+
+
+def batch(*candles: Candle) -> MT5CandleBatch:
+    return MT5CandleBatch(symbol=SYMBOL, timeframe="M15", candles=list(candles))
+
+
+def candle(timestamp: str, open_: str, high: str, low: str, close: str) -> Candle:
+    return Candle(
+        symbol=SYMBOL,
+        timestamp=timestamp,
+        index=-1,
+        open=open_,
+        high=high,
+        low=low,
+        close=close,
+    )
+
+
+class DryRunLiveLoopTests(unittest.TestCase):
+    def test_first_run_requires_explicit_seed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            loop = DryRunLiveLoop(
+                DryRunLiveConfig(
+                    symbol=SYMBOL,
+                    timeframe="M15",
+                    state_path=Path(tmpdir) / "state.json",
+                ),
+                market_data=FakeMarketData([batch()]),
+            )
+
+            with self.assertRaises(ValueError):
+                loop.run_once()
+
+    def test_first_run_processes_new_closed_candles_and_persists_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_path = Path(tmpdir) / "state.json"
+            market = FakeMarketData(
+                [
+                    batch(
+                        candle("t0", "1.12000", "1.15000", "1.11000", "1.14000"),
+                        candle("t1", "1.14000", "1.16000", "1.13000", "1.15000"),
+                    )
+                ]
+            )
+            loop = DryRunLiveLoop(
+                DryRunLiveConfig(
+                    symbol=SYMBOL,
+                    timeframe="M15",
+                    state_path=state_path,
+                    lookback=2,
+                    seed=seed(),
+                ),
+                market_data=market,
+            )
+
+            result = loop.run_once()
+            loaded = JsonStateStore(state_path).load()
+
+            self.assertEqual(result.processed_count, 2)
+            self.assertEqual(result.skipped_count, 0)
+            self.assertEqual(result.last_processed_candle_timestamp, "t1")
+            self.assertEqual(result.next_candle_index, 2)
+            self.assertEqual(result.new_commands, [])
+            self.assertEqual(loaded.last_processed_candle_timestamp, "t1")
+            self.assertEqual(loaded.next_candle_index, 2)
+            self.assertEqual(loaded.strategy_state, StrategyState.WAITING_FOR_BULLISH_OR_BEARISH_BOS)
+            self.assertEqual([candle.index for candle in loaded.candles], [0, 1])
+            self.assertEqual(market.connect_count, 1)
+            self.assertEqual(market.shutdown_count, 1)
+
+    def test_repeated_run_does_not_reprocess_same_closed_candles(self) -> None:
+        candles = batch(
+            candle("t0", "1.12000", "1.15000", "1.11000", "1.14000"),
+            candle("t1", "1.14000", "1.16000", "1.13000", "1.15000"),
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_path = Path(tmpdir) / "state.json"
+            market = FakeMarketData([candles, candles])
+            config = DryRunLiveConfig(
+                symbol=SYMBOL,
+                timeframe="M15",
+                state_path=state_path,
+                lookback=2,
+                seed=seed(),
+            )
+
+            first = DryRunLiveLoop(config, market_data=market).run_once()
+            second = DryRunLiveLoop(config, market_data=market).run_once()
+
+            self.assertEqual(first.processed_count, 2)
+            self.assertEqual(second.processed_count, 0)
+            self.assertEqual(second.skipped_count, 2)
+            self.assertEqual(second.next_candle_index, 2)
+            self.assertEqual(JsonStateStore(state_path).load().next_candle_index, 2)
+
+    def test_bos_run_emits_command_and_persists_pending_setup(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_path = Path(tmpdir) / "state.json"
+            market = FakeMarketData(
+                [
+                    batch(
+                        candle("t0", "1.12000", "1.15000", "1.09000", "1.14000"),
+                        candle("t1", "1.19000", "1.21000", "1.18000", "1.20500"),
+                    )
+                ]
+            )
+            loop = DryRunLiveLoop(
+                DryRunLiveConfig(
+                    symbol=SYMBOL,
+                    timeframe="M15",
+                    state_path=state_path,
+                    lookback=2,
+                    seed=seed(),
+                    bullish_leg_start_index=0,
+                ),
+                market_data=market,
+            )
+
+            result = loop.run_once()
+            loaded = JsonStateStore(state_path).load()
+
+            self.assertEqual(result.processed_count, 2)
+            self.assertEqual(len(result.new_commands), 1)
+            self.assertEqual(result.new_commands[0].command_type, OrderCommandType.PLACE_PENDING_LIMIT)
+            self.assertEqual(loaded.pending_setup.direction, Direction.BULLISH)
+            self.assertEqual(loaded.pending_setup.entry, Decimal("1.1175000"))
+            self.assertEqual(loaded.strategy_state, StrategyState.WAITING_FOR_BULLISH_RETRACE_ENTRY)
+            self.assertEqual(loaded.last_processed_candle_timestamp, "t1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from decimal import Decimal
+from pathlib import Path
+
+from bos75 import (
+    Candle,
+    Direction,
+    ExpansionLeg,
+    JsonStateStore,
+    OrderCommandType,
+    PendingOrderType,
+    RuntimeState,
+    StrategyState,
+    StructureLevel,
+    StructureState,
+    TradeSetup,
+)
+from bos75.models import BOSEvent, LogRecord, Position
+from bos75.orders import cancel_pending_order_from_setup, place_pending_limit_from_setup
+from bos75.persistence import RuntimeState as RuntimeStateModel
+
+
+SYMBOL = "EURUSD"
+
+
+def structure() -> StructureState:
+    return StructureState(
+        symbol=SYMBOL,
+        active_high=StructureLevel("ASH", "1.20000", "seed-high", 0),
+        active_low=StructureLevel("ASL", "1.10000", "seed-low", 0),
+    )
+
+
+def setup() -> TradeSetup:
+    bos = BOSEvent(
+        id="bos-1",
+        symbol=SYMBOL,
+        direction=Direction.BULLISH,
+        timestamp="t2",
+        candle_index=2,
+        broken_level_name="ASH",
+        broken_level_price=Decimal("1.20000"),
+        expansion_leg=ExpansionLeg(Direction.BULLISH, 0, 2),
+        protected_extreme_price=Decimal("1.10000"),
+        protected_extreme_timestamp="t0",
+        protected_extreme_index=0,
+    )
+    return TradeSetup(
+        id="setup-1",
+        symbol=bos.symbol,
+        direction=bos.direction,
+        entry=Decimal("1.12500"),
+        stop_loss=Decimal("1.10000"),
+        take_profit=Decimal("1.20000"),
+        high_anchor=bos.broken_level_price,
+        low_anchor=bos.protected_extreme_price,
+        source_bos_id=bos.id,
+        created_at=bos.timestamp,
+    )
+
+
+class RuntimeStatePersistenceTests(unittest.TestCase):
+    def test_runtime_state_round_trips_through_json(self) -> None:
+        active_setup = setup()
+        state = RuntimeState(
+            symbol=SYMBOL,
+            timeframe="M15",
+            structure=structure(),
+            last_processed_candle_timestamp="t2",
+            next_candle_index=3,
+            strategy_state=StrategyState.WAITING_FOR_BULLISH_RETRACE_ENTRY,
+            pending_setup=active_setup,
+            position=Position(id="position-1", setup=active_setup, opened_at="fill"),
+            candles=[
+                Candle(SYMBOL, "t0", 0, "1.10000", "1.15000", "1.09000", "1.14000"),
+                Candle(SYMBOL, "t1", 1, "1.14000", "1.21000", "1.13000", "1.20500"),
+            ],
+            commands=[
+                place_pending_limit_from_setup(active_setup),
+                cancel_pending_order_from_setup(
+                    active_setup,
+                    reason="same_direction_replacement",
+                    timestamp="t3",
+                    replacement_bos_id="bos-2",
+                ),
+            ],
+            logs=[
+                LogRecord(
+                    event="pending_order_placed",
+                    symbol=SYMBOL,
+                    timestamp="t2",
+                    message="placed",
+                    state_before=StrategyState.WAITING_FOR_BULLISH_OR_BEARISH_BOS,
+                    state_after=StrategyState.WAITING_FOR_BULLISH_RETRACE_ENTRY,
+                    data={"entry": Decimal("1.12500")},
+                )
+            ],
+        )
+
+        loaded = RuntimeStateModel.from_dict(json.loads(json.dumps(state.to_dict())))
+
+        self.assertEqual(loaded.symbol, SYMBOL)
+        self.assertEqual(loaded.timeframe, "M15")
+        self.assertEqual(loaded.structure.active_high.price, Decimal("1.20000"))
+        self.assertEqual(loaded.last_processed_candle_timestamp, "t2")
+        self.assertEqual(loaded.next_candle_index, 3)
+        self.assertEqual(loaded.strategy_state, StrategyState.WAITING_FOR_BULLISH_RETRACE_ENTRY)
+        self.assertEqual(loaded.pending_setup.entry, Decimal("1.12500"))
+        self.assertEqual(loaded.position.id, "position-1")
+        self.assertEqual(len(loaded.candles), 2)
+        self.assertEqual(loaded.commands[0].command_type, OrderCommandType.PLACE_PENDING_LIMIT)
+        self.assertEqual(loaded.commands[0].order_type, PendingOrderType.BUY_LIMIT)
+        self.assertEqual(loaded.commands[1].command_type, OrderCommandType.CANCEL_PENDING_ORDER)
+        self.assertEqual(loaded.logs[0].state_after, StrategyState.WAITING_FOR_BULLISH_RETRACE_ENTRY)
+
+    def test_json_state_store_returns_none_when_file_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = JsonStateStore(Path(tmpdir) / "state.json")
+
+            self.assertIsNone(store.load())
+
+    def test_json_state_store_saves_and_loads_state_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_path = Path(tmpdir) / "nested" / "state.json"
+            store = JsonStateStore(state_path)
+            state = RuntimeState(
+                symbol=SYMBOL,
+                timeframe="M15",
+                structure=structure(),
+                strategy_state=StrategyState.WAITING_FOR_BULLISH_OR_BEARISH_BOS,
+            )
+
+            store.save(state)
+            loaded = store.load()
+
+            self.assertTrue(state_path.exists())
+            self.assertEqual(loaded.symbol, SYMBOL)
+            self.assertEqual(loaded.strategy_state, StrategyState.WAITING_FOR_BULLISH_OR_BEARISH_BOS)
+
+    def test_runtime_state_rejects_unknown_schema_version(self) -> None:
+        payload = RuntimeState(symbol=SYMBOL, timeframe="M15", structure=structure()).to_dict()
+        payload["schema_version"] = 999
+
+        with self.assertRaises(ValueError):
+            RuntimeState.from_dict(payload)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Added JSON runtime persistence for strategy state, structure, candles, pending setup/position, command history, and replayable logs.
- Added a dry-run live loop that fetches MT5 closed candles, processes only new candles, persists state, and emits logs/commands without sending orders.
- Added `python -m bos75.cli live-dry-run ...` with explicit ASH/ASL seed inputs for first run.
- Added tests for persistence round-trip, missing-state behavior, duplicate candle skipping, BOS-triggering dry-run command generation, and state restore.
- Updated README and `.gitignore` for runtime `state/` files.

## Guardrails

- No automatic ASH/ASL discovery was added.
- No pivot/fractal/zigzag logic was added.
- Closed candles only.
- No MT5 `order_send` call is made by the dry-run loop.

## Validation

```powershell
python -m unittest discover -s tests -v
$env:BOS75_MT5_INTEGRATION='1'; python -m unittest tests.test_mt5_original_integration -v
python -m bos75.cli live-dry-run --symbol EURUSD --timeframe M15 --lookback 3 --state-path state/EURUSD_M15_dry_run.json --seed-ash-price 2.00000 --seed-ash-time manual-high --seed-ash-index 0 --seed-asl-price 1.00000 --seed-asl-time manual-low --seed-asl-index 0
python -m bos75.cli live-dry-run --symbol EURUSD --timeframe M15 --lookback 3 --state-path state/EURUSD_M15_dry_run.json
```

Results:

- Default suite: 54 tests passing, 2 original-terminal checks skipped by default.
- Opt-in original MT5 checks: 2 tests passing.
- First real dry-run cycle processed 3 closed EURUSD M15 candles.
- Second real dry-run cycle processed 0 and skipped the 3 already-seen candles.

Closes #4.