### PR TITLE
[codex] Add repository consistency tooling

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,38 @@
+name: Bug report
+description: Report a reproducible defect in the engine, replay flow, CLI, or MT5 adapter.
+title: "Bug: "
+labels:
+  - bug
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What went wrong?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: List the exact command, fixture, or test case that reproduces the issue.
+      placeholder: |
+        1. Run ...
+        2. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened under STRATEGY_SPEC.md?
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or output
+      description: Paste concise replay logs, CLI output, or traceback details.
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/strategy_decision.yml
+++ b/.github/ISSUE_TEMPLATE/strategy_decision.yml
@@ -1,0 +1,43 @@
+name: Strategy decision
+description: Clarify an ambiguous trading definition before implementation.
+title: "Strategy decision: "
+labels:
+  - strategy
+  - needs-decision
+body:
+  - type: input
+    id: spec-section
+    attributes:
+      label: Spec section
+      description: Which STRATEGY_SPEC.md section does this affect?
+      placeholder: "Example: 7) Seeding and warmup"
+    validations:
+      required: true
+  - type: textarea
+    id: ambiguity
+    attributes:
+      label: Ambiguity
+      description: Restate the undefined or conflicting behavior without proposing code yet.
+    validations:
+      required: true
+  - type: textarea
+    id: trading-impact
+    attributes:
+      label: Trading impact
+      description: Explain how different interpretations could change BOS, entry, stop, target, invalidation, or replay results.
+    validations:
+      required: true
+  - type: textarea
+    id: candidate-rules
+    attributes:
+      label: Candidate precise rules
+      description: List 2-3 exact rules or examples that could resolve the ambiguity.
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Required validation
+      description: Which deterministic tests, replay fixtures, or logs should prove the chosen rule?
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+- 
+
+## Validation
+
+- [ ] `python -m unittest discover -s tests -v`
+
+## Strategy Guardrails
+
+- [ ] I read `STRATEGY_SPEC.md` before changing behavior.
+- [ ] This change does not introduce fractal, zigzag, generic pivot, indicator, or optimization logic.
+- [ ] BOS behavior still uses candle-close confirmation only.
+- [ ] Any ambiguous trading definition is linked to a GitHub issue before implementation.
+- [ ] Replayable logs and deterministic tests were added or updated for material trading-rule changes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  tests:
+    name: Python tests
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+
+      - name: Run deterministic tests
+        run: python -m unittest discover -s tests -v

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Python](https://img.shields.io/badge/Python-3.11-blue)
 ![MT5](https://img.shields.io/badge/MetaTrader-5-1f6feb)
-![Tests](https://img.shields.io/badge/tests-54%20passing-brightgreen)
+![CI](https://github.com/rTalhaa/SwingautomateddTrading/actions/workflows/ci.yml/badge.svg)
 ![Status](https://img.shields.io/badge/status-active%20build-informational)
 
 A structure-first trading engine for a BOS-based 75% retracement strategy, built around deterministic replay, explicit state transitions, and an optional MetaTrader 5 execution adapter.
@@ -68,7 +68,7 @@ flowchart LR
 | `bos75/live_loop.py` | Persisted dry-run live loop over MT5 closed candles |
 | `bos75/seeding.py` | Explicit ASH/ASL seeding without automatic swing invention |
 | `bos75/replay.py` | Deterministic replay coordinator for seeded closed-candle inputs |
-| `bos75/cli.py` | Replay and MT5 safety-check commands |
+| `bos75/cli.py` | Replay, MT5 market-data, dry-run, and safety-check commands |
 | `docs/IMPLEMENTATION_RESTATEMENT.md` | Required pre-coding restatement and ambiguity register |
 
 ## Quick Start
@@ -144,9 +144,16 @@ $env:BOS75_MT5_INTEGRATION='1'; python -m unittest tests.test_mt5_original_integ
 
 ## Current Validation
 
-- The default `54`-test suite passes locally, with the 2 original-terminal checks skipped unless explicitly enabled.
+- The default suite runs `54` checks locally: `52` deterministic checks pass and 2 original-terminal checks skip unless explicitly enabled.
 - The original MT5 smoke and closed-candle fetch checks pass against a connected demo terminal when explicitly enabled.
 - Live `order_send` remains gated until terminal-side trading permission is enabled.
+
+## Repository Workflow
+
+- CI runs the deterministic test suite on pushes to `main` and on pull requests.
+- Strategy behavior changes should reference the relevant spec section or GitHub issue.
+- Ambiguous trading definitions should use the strategy-decision issue template before implementation.
+- Pull requests should confirm that no fractal, zigzag, generic pivot, indicator, or optimization shortcut was introduced.
 
 ## Open Strategy Decisions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,30 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "bos75-retracement"
 version = "0.1.0"
 description = "BOS 75% retracement strategy core"
+readme = "README.md"
 requires-python = ">=3.11"
 dependencies = []
+keywords = ["algorithmic-trading", "metatrader5", "replay-engine", "trading-strategy"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Topic :: Software Development :: Testing",
+]
 
 [project.optional-dependencies]
 mt5 = ["MetaTrader5>=5.0.5735"]
+
+[project.urls]
+Homepage = "https://github.com/rTalhaa/SwingautomateddTrading"
+Repository = "https://github.com/rTalhaa/SwingautomateddTrading"
+Issues = "https://github.com/rTalhaa/SwingautomateddTrading/issues"
 
 [tool.setuptools]
 packages = ["bos75"]


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI for the deterministic unittest suite.
- Add bug and strategy-decision issue forms plus a PR guardrail checklist.
- Update README validation wording and Python package metadata.

## Validation
- python -m pip install -e .
- python -m unittest discover -s tests -v

## Notes
- No trading behavior changed; Issue #1 remains the strategy-definition blocker for seeding and expansion-leg rules.