### PR TITLE
[codex] Update CI actions to Node 24 versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
## Summary
- Update checkout and setup-python actions to their current v6 releases.
- Clears the GitHub Actions Node 20 deprecation warning from the new CI workflow.

## Validation
- python -m unittest discover -s tests -v

## Notes
- CI action tags were verified against the upstream action repositories before updating.