### PR TITLE
[codex] Add dry-run MT5 order checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This project is intentionally conservative: it does not convert market-structure
 - Replays seeded candle fixtures with explainable logs.
 - Fetches closed candles from MT5 for replay-ready market data.
 - Runs a persisted dry-run live loop over new closed candles.
-- Validates MT5 requests safely through `order_check` before live order sending.
+- Validates emitted pending-limit requests safely through MT5 `order_check` before live order sending.
 
 ## Strategy Geometry
 
@@ -114,6 +114,8 @@ The dry-run loop processes new closed candles only, persists JSON state, and emi
 
 On later runs, the same command can omit seed arguments once the state file exists.
 
+Add `--check-orders` to validate any newly emitted pending-limit command through MT5 `order_check` while still avoiding `order_send`.
+
 ## MetaTrader 5
 
 Install the optional MT5 bridge:
@@ -144,7 +146,7 @@ $env:BOS75_MT5_INTEGRATION='1'; python -m unittest tests.test_mt5_original_integ
 
 ## Current Validation
 
-- The default suite runs `54` checks locally: `52` deterministic checks pass and 2 original-terminal checks skip unless explicitly enabled.
+- The default suite runs `56` checks locally: `54` deterministic checks pass and 2 original-terminal checks skip unless explicitly enabled.
 - The original MT5 smoke and closed-candle fetch checks pass against a connected demo terminal when explicitly enabled.
 - Live `order_send` remains gated until terminal-side trading permission is enabled.
 

--- a/bos75/__init__.py
+++ b/bos75/__init__.py
@@ -1,7 +1,12 @@
 """BOS 75% retracement strategy core."""
 
 from .execution import StrategyEngine
-from .live_loop import DryRunLiveConfig, DryRunLiveLoop, DryRunLiveResult
+from .live_loop import (
+    DryRunLiveConfig,
+    DryRunLiveLoop,
+    DryRunLiveResult,
+    DryRunOrderCheckResult,
+)
 from .models import (
     BOSEvent,
     Candle,
@@ -36,6 +41,7 @@ __all__ = [
     "DryRunLiveConfig",
     "DryRunLiveLoop",
     "DryRunLiveResult",
+    "DryRunOrderCheckResult",
     "ExecutionCommand",
     "ExpansionLeg",
     "ExplicitStructureSeed",

--- a/bos75/cli.py
+++ b/bos75/cli.py
@@ -78,6 +78,11 @@ def main(argv: list[str] | None = None) -> int:
     live_parser.add_argument("--seed-asl-index", type=int, help="Initial active structural low candle index")
     live_parser.add_argument("--bullish-leg-start-index", type=int)
     live_parser.add_argument("--bearish-leg-start-index", type=int)
+    live_parser.add_argument(
+        "--check-orders",
+        action="store_true",
+        help="Validate new pending-limit commands through MT5 order_check without sending orders",
+    )
     live_parser.add_argument("--output", type=Path, help="Optional path to write dry-run result JSON")
 
     args = parser.parse_args(argv)
@@ -122,6 +127,7 @@ def main(argv: list[str] | None = None) -> int:
             seed=_seed_from_live_args(args),
             bullish_leg_start_index=args.bullish_leg_start_index,
             bearish_leg_start_index=args.bearish_leg_start_index,
+            check_orders=args.check_orders,
         )
         output = json.dumps(result, indent=2)
         if args.output:
@@ -267,6 +273,7 @@ def run_live_dry_run(
     seed: ExplicitStructureSeed | None = None,
     bullish_leg_start_index: int | None = None,
     bearish_leg_start_index: int | None = None,
+    check_orders: bool = False,
 ) -> dict[str, Any]:
     loop = DryRunLiveLoop(
         DryRunLiveConfig(
@@ -278,6 +285,7 @@ def run_live_dry_run(
             seed=seed,
             bullish_leg_start_index=bullish_leg_start_index,
             bearish_leg_start_index=bearish_leg_start_index,
+            check_orders=check_orders,
         )
     )
     return loop.run_once().to_dict()

--- a/bos75/live_loop.py
+++ b/bos75/live_loop.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from .models import Candle, LogRecord
-from .mt5_adapter import MT5AdapterConfig
+from .mt5_adapter import MT5AdapterConfig, MT5ExecutionResult, MT5OrderAdapter
 from .mt5_market_data import MT5MarketDataAdapter
-from .orders import ExecutionCommand
+from .orders import ExecutionCommand, OrderCommandType, PlacePendingLimitCommand
 from .persistence import (
     JsonStateStore,
     RuntimeState,
@@ -28,6 +28,51 @@ class DryRunLiveConfig:
     seed: ExplicitStructureSeed | None = None
     bullish_leg_start_index: int | None = None
     bearish_leg_start_index: int | None = None
+    check_orders: bool = False
+
+
+@dataclass(frozen=True)
+class DryRunOrderCheckResult:
+    command_id: str
+    command_type: OrderCommandType
+    checked: bool
+    ok: bool | None
+    retcode: int | None = None
+    message: str = ""
+    request: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_mt5_result(cls, result: MT5ExecutionResult) -> DryRunOrderCheckResult:
+        return cls(
+            command_id=result.command_id,
+            command_type=result.command_type,
+            checked=True,
+            ok=result.ok,
+            retcode=result.retcode,
+            message=result.message,
+            request=result.request,
+        )
+
+    @classmethod
+    def skipped(cls, command: ExecutionCommand, message: str) -> DryRunOrderCheckResult:
+        return cls(
+            command_id=command.id,
+            command_type=command.command_type,
+            checked=False,
+            ok=None,
+            message=message,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "command_id": self.command_id,
+            "command_type": self.command_type.value,
+            "checked": self.checked,
+            "ok": self.ok,
+            "retcode": self.retcode,
+            "message": self.message,
+            "request": self.request,
+        }
 
 
 @dataclass(frozen=True)
@@ -41,6 +86,7 @@ class DryRunLiveResult:
     last_processed_candle_timestamp: str | None
     next_candle_index: int
     new_commands: list[ExecutionCommand]
+    order_checks: list[DryRunOrderCheckResult]
     new_logs: list[LogRecord]
     state: RuntimeState
 
@@ -58,6 +104,7 @@ class DryRunLiveResult:
             "pending_setup": trade_setup_to_dict(self.state.pending_setup),
             "position_open": self.state.position is not None,
             "new_commands": [command.to_dict() for command in self.new_commands],
+            "order_checks": [result.to_dict() for result in self.order_checks],
             "new_logs": [log.to_dict() for log in self.new_logs],
         }
 
@@ -69,12 +116,14 @@ class DryRunLiveLoop:
         *,
         state_store: JsonStateStore | None = None,
         market_data: MT5MarketDataAdapter | None = None,
+        order_adapter: MT5OrderAdapter | None = None,
     ) -> None:
         self.config = config
         self.state_store = state_store or JsonStateStore(config.state_path)
         self.market_data = market_data or MT5MarketDataAdapter(
             MT5AdapterConfig(terminal_path=config.terminal_path)
         )
+        self.order_adapter = order_adapter
 
     def run_once(self) -> DryRunLiveResult:
         state = self._load_or_initialize_state()
@@ -121,6 +170,8 @@ class DryRunLiveLoop:
             next_candle_index=next_index,
         )
         self.state_store.save(updated_state)
+        new_commands = replay.strategy.commands[previous_command_count:]
+        order_checks = self._check_new_commands(new_commands) if self.config.check_orders else []
 
         return DryRunLiveResult(
             symbol=self.config.symbol,
@@ -131,10 +182,48 @@ class DryRunLiveLoop:
             skipped_count=len(batch.candles) - len(new_candles),
             last_processed_candle_timestamp=last_processed,
             next_candle_index=next_index,
-            new_commands=replay.strategy.commands[previous_command_count:],
+            new_commands=new_commands,
+            order_checks=order_checks,
             new_logs=replay.logs[previous_log_count:],
             state=updated_state,
         )
+
+    def _check_new_commands(self, commands: list[ExecutionCommand]) -> list[DryRunOrderCheckResult]:
+        if not commands:
+            return []
+
+        if not any(isinstance(command, PlacePendingLimitCommand) for command in commands):
+            return [
+                DryRunOrderCheckResult.skipped(
+                    command,
+                    "order_check is available for pending-limit placement only; cancellation was not sent",
+                )
+                for command in commands
+            ]
+
+        adapter = self.order_adapter or MT5OrderAdapter(
+            MT5AdapterConfig(terminal_path=self.config.terminal_path)
+        )
+        adapter.connect()
+        try:
+            results: list[DryRunOrderCheckResult] = []
+            for command in commands:
+                if isinstance(command, PlacePendingLimitCommand):
+                    results.append(
+                        DryRunOrderCheckResult.from_mt5_result(
+                            adapter.check_pending_limit(command)
+                        )
+                    )
+                    continue
+                results.append(
+                    DryRunOrderCheckResult.skipped(
+                        command,
+                        "order_check is available for pending-limit placement only; cancellation was not sent",
+                    )
+                )
+            return results
+        finally:
+            adapter.shutdown()
 
     def _load_or_initialize_state(self) -> RuntimeState:
         existing = self.state_store.load()

--- a/tests/test_live_loop.py
+++ b/tests/test_live_loop.py
@@ -12,6 +12,7 @@ from bos75 import (
     DryRunLiveLoop,
     ExplicitStructureSeed,
     JsonStateStore,
+    MT5ExecutionResult,
     OrderCommandType,
     StrategyState,
 )
@@ -39,6 +40,30 @@ class FakeMarketData:
         if len(self.fetch_calls) <= len(self.batches):
             return self.batches[len(self.fetch_calls) - 1]
         return self.batches[-1]
+
+
+class FakeOrderAdapter:
+    def __init__(self) -> None:
+        self.connect_count = 0
+        self.shutdown_count = 0
+        self.checked_commands = []
+
+    def connect(self) -> None:
+        self.connect_count += 1
+
+    def shutdown(self) -> None:
+        self.shutdown_count += 1
+
+    def check_pending_limit(self, command):
+        self.checked_commands.append(command)
+        return MT5ExecutionResult(
+            command_id=command.id,
+            command_type=command.command_type,
+            ok=True,
+            retcode=0,
+            request={"symbol": command.symbol, "price": float(command.entry)},
+            message="Done",
+        )
 
 
 def seed() -> ExplicitStructureSeed:
@@ -179,6 +204,88 @@ class DryRunLiveLoopTests(unittest.TestCase):
             self.assertEqual(loaded.pending_setup.entry, Decimal("1.1175000"))
             self.assertEqual(loaded.strategy_state, StrategyState.WAITING_FOR_BULLISH_RETRACE_ENTRY)
             self.assertEqual(loaded.last_processed_candle_timestamp, "t1")
+            self.assertEqual(result.order_checks, [])
+
+    def test_check_orders_validates_new_pending_limit_commands_without_sending(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            market = FakeMarketData(
+                [
+                    batch(
+                        candle("t0", "1.12000", "1.15000", "1.09000", "1.14000"),
+                        candle("t1", "1.19000", "1.21000", "1.18000", "1.20500"),
+                    )
+                ]
+            )
+            order_adapter = FakeOrderAdapter()
+            loop = DryRunLiveLoop(
+                DryRunLiveConfig(
+                    symbol=SYMBOL,
+                    timeframe="M15",
+                    state_path=Path(tmpdir) / "state.json",
+                    lookback=2,
+                    seed=seed(),
+                    bullish_leg_start_index=0,
+                    check_orders=True,
+                ),
+                market_data=market,
+                order_adapter=order_adapter,
+            )
+
+            result = loop.run_once()
+            serialized = result.to_dict()
+
+            self.assertEqual(len(result.new_commands), 1)
+            self.assertEqual(len(order_adapter.checked_commands), 1)
+            self.assertEqual(order_adapter.checked_commands[0].id, result.new_commands[0].id)
+            self.assertEqual(order_adapter.connect_count, 1)
+            self.assertEqual(order_adapter.shutdown_count, 1)
+            self.assertEqual(serialized["order_checks"][0]["checked"], True)
+            self.assertEqual(serialized["order_checks"][0]["ok"], True)
+            self.assertEqual(serialized["order_checks"][0]["retcode"], 0)
+            self.assertEqual(serialized["order_checks"][0]["message"], "Done")
+
+    def test_check_orders_reports_cancel_commands_as_skipped_without_sending(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            market = FakeMarketData(
+                [
+                    batch(
+                        candle("t0", "1.12000", "1.15000", "1.09000", "1.14000"),
+                        candle("t1", "1.19000", "1.21000", "1.18000", "1.20500"),
+                        candle("t2", "1.20500", "1.21500", "1.08000", "1.09500"),
+                    )
+                ]
+            )
+            order_adapter = FakeOrderAdapter()
+            loop = DryRunLiveLoop(
+                DryRunLiveConfig(
+                    symbol=SYMBOL,
+                    timeframe="M15",
+                    state_path=Path(tmpdir) / "state.json",
+                    lookback=3,
+                    seed=seed(),
+                    bullish_leg_start_index=0,
+                    bearish_leg_start_index=0,
+                    check_orders=True,
+                ),
+                market_data=market,
+                order_adapter=order_adapter,
+            )
+
+            result = loop.run_once()
+            serialized_checks = result.to_dict()["order_checks"]
+
+            self.assertEqual(
+                [command.command_type for command in result.new_commands],
+                [
+                    OrderCommandType.PLACE_PENDING_LIMIT,
+                    OrderCommandType.CANCEL_PENDING_ORDER,
+                    OrderCommandType.PLACE_PENDING_LIMIT,
+                ],
+            )
+            self.assertEqual(len(order_adapter.checked_commands), 2)
+            self.assertEqual([check["checked"] for check in serialized_checks], [True, False, True])
+            self.assertIsNone(serialized_checks[1]["ok"])
+            self.assertIn("cancellation was not sent", serialized_checks[1]["message"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add opt-in live-dry-run order validation with --check-orders.
- Return serialized order_checks beside newly emitted dry-run commands.
- Validate pending-limit commands with MT5 order_check and report cancellation commands as skipped without sending anything.
- Document the new flag and updated test count.

## Validation
- python -m unittest tests.test_live_loop -v
- python -m unittest discover -s tests -v
- $env:BOS75_MT5_INTEGRATION='1'; python -m unittest tests.test_mt5_original_integration -v`n- Real MT5 live-dry-run with --check-orders and no emitted command
- Real MT5 live-dry-run with --check-orders and one emitted buy-limit dry-run command; MT5 returned retcode 0 / Done

## Strategy Guardrails
- Read STRATEGY_SPEC.md before changes.
- No structure detection, seeding, BOS, setup geometry, or live order-send behavior changed.
- No fractal, zigzag, generic pivot, indicator, or optimization logic introduced.

Closes #8